### PR TITLE
Fuzzy corporation count

### DIFF
--- a/api/process.py
+++ b/api/process.py
@@ -3,6 +3,7 @@ from flask import request, abort
 from .utils import (
     diff,
     export,
+    fuzzyfy,
     read_csv,
     filename,
     diff_frames,
@@ -30,7 +31,11 @@ def corporation_count():
     df = df[condo_coop_mask(df)]
     df = df[['RegistrationID', 'CorporationName']].drop_duplicates()
     df = df.groupby(['CorporationName']).size().sort_values(
-        ascending=False).reset_index(name='count')
+        ascending=False).reset_index(name='Count')
+
+    likeness = int(request.form.get('likeness') or 0)
+    if likeness:
+        df = fuzzyfy(df, likeness)
     return export(
         df, f'corporation-count-{filename(file, "registration")}.csv')
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-![showcase](https://user-images.githubusercontent.com/23444983/184568495-cbcf35ef-32ce-4851-8674-c837ae863b55.png)
+![showcase](https://user-images.githubusercontent.com/23444983/186924328-d6439361-5fb3-45bd-a4ee-77715e588b3f.png)
 
 ## Vat iz thiz?!
 
@@ -30,6 +30,9 @@ It's a utility to perform analytics on csv data. Specifically, NYC [Buildings](h
    ```
 
 3. Run the server using `python main.py` and head over to http://localhost:8000/ to blast away your exotic csv! 🚀 🥙
+
+## Security
+Try to avoid saving and reading files from server storage. As of now, the primary hosting environment of this project is public on replit - making it an easy target for expolit - especially when we're dealing with the excel format. If you absolutely must do server-side file IO, thoroughly sanitize both the local and remote input to your rpc function. Once you've eliminated all potential edge cases, you'll still not be safe 👨‍💻
 
 ## Dataset direct links
 [All-Buildings-Subject-to-HPD-Jurisdiction](https://data.cityofnewyork.us/api/views/kj4p-ruqc/rows.csv?accessType=DOWNLOAD)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 flask
+pandas
 gevent
 openpyxl
 csv-diff

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ gevent
 openpyxl
 csv-diff
 flask_compress
+thefuzz[speedup]

--- a/static/style.css
+++ b/static/style.css
@@ -30,3 +30,7 @@ form input[type='text'] {
 .file-label:hover .file-cta {
   background-color: #c5c9a4;
 }
+
+input:not([type="file"]) {
+  margin: 0.35rem 0;
+}

--- a/templates/main.html
+++ b/templates/main.html
@@ -20,9 +20,18 @@
 </head>
 <body>
   <form action="/process" method="post" enctype="multipart/form-data">
-    <div class="header">Corporation Count</div>
+    <div class="header">Fuzzy Corporation Count</div>
     <input type="hidden" name="function" value="corporation_count" />
-    {{ forms.file(name='registration', label='Choose a file...') }}
+    {{ forms.file(name='registration', label='Choose a contacts file...') }}
+    <label for="likeness">Likeness</label>
+    <input
+      min="0"
+      max="100"
+      value="90"
+      type="number"
+      name="likeness"
+      title="Value between 0-100. For e.g. 90 will group together names that are 90% similar"
+    /><br>
     <input type="submit" value="Process" />
   </form>
   <form action="/process" method="post" enctype="multipart/form-data">
@@ -39,7 +48,6 @@
     {{ forms.file(name='old', label='Choose old file...') }}
     {{ forms.file(name='new', label='Choose new file...') }}
     <input
-      type="text"
       name="index-column"
       value="IndexID"
       title="Index column to compare against"


### PR DESCRIPTION
Corporation names in registration CSV contain a lot of spelling errors. As a result, a simple groupby and count operation does not accurately portray true corporation repetition figures. With the ability to group similar names, we can considerably improve the analysis.

#### Implementation Notes
- **pandas** dataframe indexing is slower compared to raw python data-structures. Taking this into account, a slight [revision](https://github.com/ScottWOlson/ScottWOlson/pull/2/commits/5871971ba5482e8ad7c9427ab8ca48d1c46a4bea#diff-1927a2a7260bf138319644bceb09095e47b82f13b79db71504801f8705c00394) resulted in a **3%** boost.
- For complexity, while we can't do better than O(n²), but the scale factor has been substantially improved (**77%**) with the appropriate data-structures and algorithm. This has enabled platforms like replit, with conservative cpu alotments, to compute results within a resonable amount of time.