### PR TITLE
Aggregate business columns with fuzzy corporation count and other customizations

### DIFF
--- a/api/process.py
+++ b/api/process.py
@@ -89,16 +89,15 @@ def compare_contacts():
         show_atleast=[*index, 'BusinessZip'],
         removed_mask=condo_coop_mask)
 
+    cols = ['BuildingID', 'Zip', 'RegistrationID']
+    additional_cols = request.form.get('building-columns')
+    if additional_cols:
+        cols += additional_cols.split(',')
+
     if not dfc.empty:
         buildings = read_csv(
             buildings,
-            usecols=[
-                'BuildingID',
-                'RegistrationID',
-                'LowHouseNumber',
-                'HighHouseNumber',
-                'StreetName',
-                'Zip'],
+            usecols=cols,
             dtype={'BuildingID': 'Int64', 'Zip': 'string'})
 
         dfc = post_process_contacts(

--- a/api/process.py
+++ b/api/process.py
@@ -1,7 +1,5 @@
-from flask import request, abort
-import pandas as pd
+from flask import request
 from .utils import (
-    diff,
     export,
     fuzzyfy,
     read_csv,
@@ -108,20 +106,3 @@ def compare_contacts():
             col_order={'first': ['ChangeType', *index], 'last': ['BusinessZip', 'Zip', 'ZipMatch']})
 
     return export(dfc, f'compare-{old_name}-{new_name}.xlsx')
-
-
-@register
-def compare():
-    index = request.form.get('index-column')
-    if not index:
-        abort(400, 'Index column is required! 👉👈')
-
-    old_file = request.files.get('old')
-    new_file = request.files.get('new')
-
-    old_name = filename(old_file, 'old')
-    new_name = filename(new_file, 'new')
-
-    df = diff(old_file, new_file, index)
-
-    return export(df, f'compare-{old_name}-{new_name}.csv')

--- a/api/process.py
+++ b/api/process.py
@@ -59,25 +59,8 @@ def compare_contacts():
         'LastName'
     ]
 
-    read_contacts_args = {
-        # 'lower_case': True,
-        # 'default_dtype': 'string',
-        'dtype': {
-            'RegistrationContactID': 'Int64',
-            'RegistrationID': 'Int64'
-        },
-    }
-    contacts_old = prepare_contacts(
-        read_csv(
-            contacts_old,
-            **read_contacts_args),
-        index,
-        old=True)
-    contacts_new = prepare_contacts(
-        read_csv(
-            contacts_new,
-            **read_contacts_args),
-        index)
+    contacts_old = prepare_contacts(contacts_old, index)
+    contacts_new = prepare_contacts(contacts_new, index, new=True)
 
     # copy not necessary at this point but
     # in case diff alters contacts df in future
@@ -100,14 +83,14 @@ def compare_contacts():
         buildings = read_csv(
             buildings,
             usecols=cols,
-            dtype={'BuildingID': 'Int64', 'Zip': 'string'})
+            dtype={'BuildingID': 'UInt32', 'RegistrationID': 'UInt32', 'Zip': 'string'})
 
         dfc = post_process_contacts(
             dfc,
             buildings,
             old_rids=old_rids,
             col_order={'first': ['ChangeType', *index], 'last': ['BusinessZip', 'Zip', 'ZipMatch']})
-        
+
         del buildings
         del old_rids
 

--- a/api/process.py
+++ b/api/process.py
@@ -38,8 +38,9 @@ def corporation_count():
         df = fuzzyfy(
             df, similarity,
             parse_list(request.form.get('ignore-keywords')))
-    return export(
-        df, f'corporation-count-{filename(contacts_file, "registration")}-{similarity}.csv')
+
+    file_name = filename(contacts_file, 'registration')
+    return export(df, f'corporation-count-{file_name}-{similarity}.csv')
 
 
 @register
@@ -56,14 +57,12 @@ def compare_contacts():
         'RegistrationID',
         'FirstName',
         'MiddleInitial',
-        'LastName'
+        'LastName',
     ]
 
     contacts_old = prepare_contacts(contacts_old, index)
     contacts_new = prepare_contacts(contacts_new, index, new=True)
 
-    # copy not necessary at this point but
-    # in case diff alters contacts df in future
     old_rids = contacts_old['RegistrationID'].copy()
 
     dfc = diff_frames(
@@ -73,25 +72,21 @@ def compare_contacts():
         show_atleast=[*index, 'BusinessZip'],
         removed_mask=condo_coop_mask)
 
-    del contacts_old
-    del contacts_new
+    del contacts_old, contacts_new
 
-    cols = ['BuildingID', 'Zip', 'RegistrationID'] + \
+    columns = ['BuildingID', 'Zip', 'RegistrationID'] + \
         parse_list(request.form.get('building-columns'))
 
     if not dfc.empty:
-        buildings = read_csv(
-            buildings,
-            usecols=cols,
-            dtype={'BuildingID': 'UInt32', 'RegistrationID': 'UInt32', 'Zip': 'string'})
+        buildings = read_csv(buildings, usecols=columns,
+                             dtype={'BuildingID': 'UInt32',
+                                    'RegistrationID': 'UInt32'})
 
         dfc = post_process_contacts(
-            dfc,
-            buildings,
-            old_rids=old_rids,
-            col_order={'first': ['ChangeType', *index], 'last': ['BusinessZip', 'Zip', 'ZipMatch']})
+            dfc, buildings, old_rids=old_rids,
+            col_order={'first': ['ChangeType', *index],
+                       'last': ['BusinessZip', 'Zip', 'ZipMatch']})
 
-        del buildings
-        del old_rids
+        del buildings, old_rids
 
     return export(dfc, f'compare-{old_name}-{new_name}.xlsx')

--- a/api/process.py
+++ b/api/process.py
@@ -60,7 +60,7 @@ def compare_contacts():
     ]
 
     read_contacts_args = {
-        # 'lower_case': True
+        # 'lower_case': True,
         # 'default_dtype': 'string',
         'dtype': {
             'RegistrationContactID': 'Int64',
@@ -90,6 +90,9 @@ def compare_contacts():
         show_atleast=[*index, 'BusinessZip'],
         removed_mask=condo_coop_mask)
 
+    del contacts_old
+    del contacts_new
+
     cols = ['BuildingID', 'Zip', 'RegistrationID'] + \
         parse_list(request.form.get('building-columns'))
 
@@ -104,5 +107,8 @@ def compare_contacts():
             buildings,
             old_rids=old_rids,
             col_order={'first': ['ChangeType', *index], 'last': ['BusinessZip', 'Zip', 'ZipMatch']})
+        
+        del buildings
+        del old_rids
 
     return export(dfc, f'compare-{old_name}-{new_name}.xlsx')

--- a/api/utils.py
+++ b/api/utils.py
@@ -169,7 +169,7 @@ def fuzzyfy(df, similarity=90, ignore_keywords=[]):
             # faster than regex
             for word in ignore_keywords:
                 processed = processed.replace(word, '')
-            return " ".join(sorted(processed.split()))
+            return processed
         return s
 
     size = len(df.columns)
@@ -187,8 +187,8 @@ def fuzzyfy(df, similarity=90, ignore_keywords=[]):
             compare,
             limit=None,
             processor=None,
-            scorer=fuzz.ratio,
-            score_cutoff=similarity)
+            score_cutoff=similarity,
+            scorer=fuzz.token_set_ratio)
 
         # Steering away from dataframe indexing required when groupby.agg was used,
         # provided considerable performance benefit. Now with rapidfuzz,

--- a/api/utils.py
+++ b/api/utils.py
@@ -60,7 +60,7 @@ def export(df, download_name):
 
 def fuzzyfy(df, similarity=90):
     """
-    Grouby and sum Count of fuzzyfied names:
+    Groupby and sum Count of fuzzyfied names:
     - names are pre-processed using token sort.
     - grouped together based on `similarity` factor.
     - finally, their Count is aggregated as FuzzyCount.
@@ -82,13 +82,13 @@ def fuzzyfy(df, similarity=90):
         ratios from previous iterations leads to a worse similarity score,
         the time complexity may be substantially improved.
         Indel/Levenshtein edit distancing is a lossy operation by nature
-        but, perhaps a upper bound exists to help filter similar ratios
+        but, perhaps an upper bound exists to help filter similar ratios
         for successive iterations. With the right ordering of names, exponential decay
         of comparison input size will result in a different function class altogether!
 
     Parameters
     ----------
-    df        : dataframe with Name: string, Count: number columns
+    df          : dataframe with Name: string, Count: number columns
     similarity  : number between 0-100; names to be considered within the same group,
                 if they are `similarity` percent match
 

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ It's a utility to perform analytics on csv data. Specifically, NYC [Buildings](h
 3. Run the server using `python main.py` and head over to http://localhost:8000/ to blast away your exotic csv! 🚀 🥙
 
 ## Security
-Try to avoid saving and reading files from server storage. As of now, the primary hosting environment of this project is public on replit - making it an easy target for expolit - especially when we're dealing with the excel format. If you absolutely must do server-side file IO, thoroughly sanitize both the local and remote input to your rpc function. Once you've eliminated all potential edge cases, you'll still not be safe 👨‍💻
+Try to avoid saving and reading files from server storage. As of now, the primary hosting environment of this project is public on replit - making it an easy target for exploit - especially when we're dealing with the excel format. If you absolutely must do server-side file IO, thoroughly sanitize both the local and remote input to your rpc function. Once you've eliminated all potential edge cases, you'll still not be safe 👨‍💻
 
 ## Dataset direct links
 [All-Buildings-Subject-to-HPD-Jurisdiction](https://data.cityofnewyork.us/api/views/kj4p-ruqc/rows.csv?accessType=DOWNLOAD)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ flask
 pandas
 gevent
 openpyxl
-csv-diff
 rapidfuzz
 flask_compress

--- a/static/style.css
+++ b/static/style.css
@@ -6,7 +6,7 @@ body {
   display: grid;
   align-items: center;
   justify-content: center;
-  gap: 1rem;
+  gap: 2rem;
 }
 
 @media screen and (min-width: 800px) {
@@ -28,6 +28,10 @@ body {
   background-color: #c5c9a4;
 }
 
-input:not([type="file"]) {
-  margin: 0.15rem 0;
+input {
+  margin-bottom: 0.35rem;
+}
+
+input[type="submit"] {
+  margin: 0.20rem 0;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -4,7 +4,7 @@ body {
   font: 1rem/1.5 'PT Sans', Arial, sans-serif;
   color: #1c0221;
   display: grid;
-  align-items: center;
+  align-items: top;
   justify-content: center;
   gap: 2rem;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -16,11 +16,8 @@ body {
 }
 
 .header {
-  font-size: larger;
-}
-
-form input[type='text'] {
-  margin: 0.35rem 0;
+  font-size: x-large;
+  margin-bottom: 0.5rem;
 }
 
 .file {
@@ -32,5 +29,5 @@ form input[type='text'] {
 }
 
 input:not([type="file"]) {
-  margin: 0.35rem 0;
+  margin: 0.15rem 0;
 }

--- a/templates/macros/forms.html
+++ b/templates/macros/forms.html
@@ -1,7 +1,7 @@
 {% macro file(name, label) %}
 <div class="file" title="{{ label }}">
   <label class="file-label">
-    <input class="file-input" type="file" name="{{ name }}" multiple/>
+    <input class="file-input" type="file" name="{{ name }}" accept="text/csv"/>
     <span class="file-cta">
       <span class="file-icon">
         <i class="fas fa-upload"></i>

--- a/templates/main.html
+++ b/templates/main.html
@@ -28,7 +28,7 @@
         name="filter-keywords"
         value="street,condominium"
         title="Comma separated list of case-insensitive keywords to discard corporation names that contain them"
-        style="width: 85%"
+        style="width: 90%"
       />
     </div>
     <div>
@@ -37,7 +37,7 @@
         name="ignore-keywords"
         value="property,management,services,corp,inc,real estate"
         title="Comma separated list of case-insensitive keywords to ignore when computing fuzzy similarity"
-        style="width: 85%"
+        style="width: 90%"
       />
     </div>
     <div>
@@ -46,12 +46,12 @@
         name="building-columns"
         value="LegalClassA"
         title="Comma separated list of columns to sum from buildings CSV"
-        style="width: 85%"
+        style="width: 90%"
       />
     </div>
     {{ forms.file(name='buildings', label='Choose a buildings file...') }}
     {{ forms.file(name='registration', label='Choose a contacts file...') }}
-    <div>
+    <div style="margin-top: 0.7rem">
       <label for="similarity">Similarity</label>
       <input
         min="0"
@@ -73,25 +73,12 @@
         name="building-columns"
         value="LowHouseNumber,HighHouseNumber,HouseNumber,LegalClassA,StreetName"
         title="Comma separated list of columns to show from the buildings CSV, in addition to BuildingID and Zip"
-        style="width: 85%"
+        style="width: 90%"
       />
     </div>
     {{ forms.file(name='buildings', label='Choose buildings file...') }}
     {{ forms.file(name='contacts-old', label='Choose old contacts file...') }}
     {{ forms.file(name='contacts-new', label='Choose new contacts file...') }}
-    <!-- <br> -->
-    <input type="submit" value="Process" />
-  </form>
-  <form action="/process" method="post" enctype="multipart/form-data">
-    <div class="header">Compare Arbitrary CSVs</div>
-    <input type="hidden" name="function" value="compare" />
-    {{ forms.file(name='old', label='Choose old file...') }}
-    {{ forms.file(name='new', label='Choose new file...') }}
-    <input
-      name="index-column"
-      value="IndexID"
-      title="Index column to compare against"
-    />
     <input type="submit" value="Process" />
   </form>
   <script src="/static/index.js"></script>

--- a/templates/main.html
+++ b/templates/main.html
@@ -38,6 +38,14 @@
       title="Comma separated list of case-insensitive keywords to ignore when computing fuzzy similarity"
       style="width: 85%"
     />
+    <label for="building-columns">Building Columns</label>
+    <input
+      name="building-columns"
+      value="LegalClassA"
+      title="Comma separated list of columns to sum from buildings CSV"
+      style="width: 85%"
+    />
+    {{ forms.file(name='buildings', label='Choose a buildings file...') }}
     {{ forms.file(name='registration', label='Choose a contacts file...') }}
     <label for="similarity">Similarity</label>
     <input

--- a/templates/main.html
+++ b/templates/main.html
@@ -31,43 +31,51 @@
         style="width: 85%"
       />
     </div>
-    <label for="ignore-keywords">Ignore Keywords</label>
-    <input
-      name="ignore-keywords"
-      value="property,management,services,corp,inc,real estate"
-      title="Comma separated list of case-insensitive keywords to ignore when computing fuzzy similarity"
-      style="width: 85%"
-    />
-    <label for="building-columns">Building Columns</label>
-    <input
-      name="building-columns"
-      value="LegalClassA"
-      title="Comma separated list of columns to sum from buildings CSV"
-      style="width: 85%"
-    />
+    <div>
+      <label for="ignore-keywords">Ignore Keywords</label>
+      <input
+        name="ignore-keywords"
+        value="property,management,services,corp,inc,real estate"
+        title="Comma separated list of case-insensitive keywords to ignore when computing fuzzy similarity"
+        style="width: 85%"
+      />
+    </div>
+    <div>
+      <label for="building-columns">Building Columns</label>
+      <input
+        name="building-columns"
+        value="LegalClassA"
+        title="Comma separated list of columns to sum from buildings CSV"
+        style="width: 85%"
+      />
+    </div>
     {{ forms.file(name='buildings', label='Choose a buildings file...') }}
     {{ forms.file(name='registration', label='Choose a contacts file...') }}
-    <label for="similarity">Similarity</label>
-    <input
-      min="0"
-      max="100"
-      value="90"
-      type="number"
-      name="similarity"
-      title="Value between 0-100. For e.g. 90 will group together names that are 90% similar"
-    /><br>
+    <div>
+      <label for="similarity">Similarity</label>
+      <input
+        min="0"
+        max="100"
+        value="90"
+        type="number"
+        name="similarity"
+        title="Value between 0-100. For e.g. 90 will group together names that are 90% similar"
+      />
+    </div>
     <input type="submit" value="Process" />
   </form>
   <form action="/process" method="post" enctype="multipart/form-data">
     <div class="header">Compare Registrations</div>
     <input type="hidden" name="function" value="compare_contacts" />
-    <label for="building-columns">Additional Building Columns</label>
-    <input
-      name="building-columns"
-      value="LowHouseNumber,HighHouseNumber,HouseNumber,LegalClassA,StreetName"
-      title="Comma separated list of columns to show from the buildings CSV, in addition to BuildingID and Zip"
-      style="width: 85%"
-    />
+    <div>
+      <label for="building-columns">Additional Building Columns</label>
+      <input
+        name="building-columns"
+        value="LowHouseNumber,HighHouseNumber,HouseNumber,LegalClassA,StreetName"
+        title="Comma separated list of columns to show from the buildings CSV, in addition to BuildingID and Zip"
+        style="width: 85%"
+      />
+    </div>
     {{ forms.file(name='buildings', label='Choose buildings file...') }}
     {{ forms.file(name='contacts-old', label='Choose old contacts file...') }}
     {{ forms.file(name='contacts-new', label='Choose new contacts file...') }}

--- a/templates/main.html
+++ b/templates/main.html
@@ -37,9 +37,17 @@
   <form action="/process" method="post" enctype="multipart/form-data">
     <div class="header">Compare Registrations</div>
     <input type="hidden" name="function" value="compare_contacts" />
+    <label for="building-columns">Additional Building Columns</label>
+    <input
+      name="building-columns"
+      value="LowHouseNumber,HighHouseNumber,HouseNumber,LegalClassA,StreetName"
+      title="Comma separated list of columns to show from the buildings CSV, in addition to BuildingID and Zip"
+      style="width: 85%"
+    />
     {{ forms.file(name='buildings', label='Choose buildings file...') }}
     {{ forms.file(name='contacts-old', label='Choose old contacts file...') }}
     {{ forms.file(name='contacts-new', label='Choose new contacts file...') }}
+    <!-- <br> -->
     <input type="submit" value="Process" />
   </form>
   <form action="/process" method="post" enctype="multipart/form-data">

--- a/templates/main.html
+++ b/templates/main.html
@@ -22,6 +22,22 @@
   <form action="/process" method="post" enctype="multipart/form-data">
     <div class="header">Fuzzy Corporation Count</div>
     <input type="hidden" name="function" value="corporation_count" />
+    <div>
+      <label for="filter-keywords">Filter Keywords</label>
+      <input
+        name="filter-keywords"
+        value="street,condominium"
+        title="Comma separated list of case-insensitive keywords to discard corporation names that contain them"
+        style="width: 85%"
+      />
+    </div>
+    <label for="ignore-keywords">Ignore Keywords</label>
+    <input
+      name="ignore-keywords"
+      value="property,management,services,corp,inc,real estate"
+      title="Comma separated list of case-insensitive keywords to ignore when computing fuzzy similarity"
+      style="width: 85%"
+    />
     {{ forms.file(name='registration', label='Choose a contacts file...') }}
     <label for="similarity">Similarity</label>
     <input


### PR DESCRIPTION
#### Corporation Count
- switch to token set ratio for improved matching.
- `fuzzyfy` has been generalized to groupby and sum arbitrary number of columns.
- support for aggregating arbitrary business csv columns - customizable through ui.
- expose keywords inputs for filtering and pre-processing corporation names before fuzzy ratio computation.

#### Registration Comparison
- ability to customize business csv columns that are shown in the diff.
- lower case performs well with limited memory.